### PR TITLE
Support for compiling anywhere

### DIFF
--- a/prototype/src/Makevars
+++ b/prototype/src/Makevars
@@ -1,9 +1,11 @@
 # -*-makefile-*-
 OBJECTS = cpp11.o sirs.o sirs_gpu.o
-PKG_LIBS = -lcudart
+PKG_LIBS = -lcudart $(SHLIB_OPENMP_CXXFLAGS)
+
+PKG_CXXFLAGS=-DHAVE_INLINE $(SHLIB_OPENMP_CXXFLAGS)
 
 NVCC = nvcc
-NVCC_FLAGS = -O2 -G -I. -I$(R_HOME)/include $(DUST_FLAGS) -Xcompiler -fPIC -x cu
+NVCC_FLAGS = -O2 -I. -I$(R_HOME)/include $(CLINK_CPPFLAGS) -Xcompiler -fPIC -x cu
 
 %.o: %.cu
 	$(NVCC) $(NVCC_FLAGS) -c $< -o $@


### PR DESCRIPTION
This has the correct secret sauce to get the paths to cpp11 (and eventually dust) added to the nvcc compiler args